### PR TITLE
Docs(#20): Create PR template for dev to main

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/dev_pr.md
+++ b/.github/PULL_REQUEST_TEMPLATE/dev_pr.md
@@ -1,0 +1,22 @@
+PRs into dev contained all info we needed. They have already been reviewed. If you've got this far we're in good shape!
+
+### List PRs
+
+List the PRs that made it into dev that are waiting to be pulled into main:
+
+* PR #? which fixes #?  
+* PR #? which fixes #?   
+
+### Types of changes
+
+What types of changes does code introduce? Put an `x` in the boxes that apply.
+This will inform the new release number.
+
+- [ ] Bugfix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation Update (if none of the other choices apply) 
+
+### Reviewer instructions
+
+The underlying PRs should already have been reviewed.


### PR DESCRIPTION
### Justification
I think having a `dev` to `main` pull request template will be a helpful tool. At the very least, we can use it while we're developing and remove it if it seems too niche for this repository when we're done.

Resolves #20 

### Types of changes

What types of changes does your code introduce? Put an `x` in the boxes that apply
- [x] Other change (if none of the other choices apply) 

### Reviewer instructions:
Basic review of syntax.