### PR TITLE
Build(#19): Modernize gitleaks action for Node.js 24

### DIFF
--- a/.github/workflows/secretScan.yml
+++ b/.github/workflows/secretScan.yml
@@ -6,7 +6,7 @@ jobs:
   gitleaks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: '0'
       - name: gitleaks-action


### PR DESCRIPTION
### Justification
Node.js 24 comes this summer and with it the deprecation of many Github actions. I've replaced the checkout action from v4 to v6 to ensure future compatibility with the node bump. Resolves #19 

### Types of changes
- [x] Other change (if none of the other choices apply)

### Further comments
There is still a deprecated function being flagged called `set-output`. I did some brief digging and I think this is occurring within the gitleaks action itself. I'm guessing that this is also related to the upcoming node bump. There is an [open issue](https://github.com/gitleaks/gitleaks-action/issues/209) on the gitleaks repo regarding the node bump. I will keep an eye on this since we're using it across so many products.

### Reviewer instructions:
Basic review for syntax.