### PR TITLE
Docs(#28): Cleanup documentation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Version: 0.0.0.9000
 Authors@R: 
     person("Katherine", "Gallagher", , "katherine.gallagher@noaa.gov", role = c("aut", "cre"))
 Description: This package provides the tools to build a spatial Climate Vulnerability Assessment. This includes pulling and formatting the necessary MOM6 and fisheries data; building and predicting component and ensemble models; calculating exposure from model predictions; and calculating and bootstrapping sensitivity from expert scores. 
-License: MIT + file LICENSE
+License: file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.3

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ pak::pak("NEFSC/READ-EDAB-CVA2.0")
 ## Contact
 
 | [Katherine Gallagher](https://github.com/KGallagher7)
-|--------------------------------
-| [![Katherine Gallagher avatar](https://avatars.githubusercontent.com/u/203711305?s=100&v4)](https://github.com/KGallagher7) |
+|:--------------------------------:
+| <a href="https://github.com/KGallagher7"><img src="https://avatars.githubusercontent.com/u/203711305?v=4" alt="Katherine Gallagher avatar" width="100" align="center"></a> |
 
 #### Legal disclaimer
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ pak::pak("NEFSC/spatialcva")
 
 | [Katherine Gallagher](https://github.com/KGallagher7)
 |--------------------------------
-| [![](https://avatars.githubusercontent.com/u/203711305?v=4)](https://github.com/KGallagher7) |
+| [![Katherine Gallagher avatar](https://avatars.githubusercontent.com/u/203711305?s=100%v=4)](https://github.com/KGallagher7) |
 
 #### Legal disclaimer
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ performing exposure, and sensitivity calculations - for the Climate Vulnerabilit
 The `spatialcva` package can be installed using the following code:
 
 ``` r
-pak::pak("NEFSC/spatialcva")
+pak::pak("NEFSC/READ-EDAB-CVA2.0")
 ```
 
 ## Contact

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ pak::pak("NEFSC/READ-EDAB-CVA2.0")
 
 | [Katherine Gallagher](https://github.com/KGallagher7)
 |--------------------------------
-| [![Katherine Gallagher avatar](https://avatars.githubusercontent.com/u/203711305?s=100%v=4)](https://github.com/KGallagher7) |
+| [![Katherine Gallagher avatar](https://avatars.githubusercontent.com/u/203711305?s=100&v4)](https://github.com/KGallagher7) |
 
 #### Legal disclaimer
 


### PR DESCRIPTION
### Justification
These changes address the oversized avatar image and its lack of alt text, incorrect installation instructions and unnecessary inclusion of the MIT license. This should improve the aesthetics and functionality of the README as well as correct the LICENSE included on the package website and in package documentation.

Fixes #28 

### Types of changes
- [x] Other change (if none of the other choices apply)

### Further comments
After reviewing myself, I found that the avatar resizing did not work (I did not notice until checking Github's preview of it). For some reason, the typical URL syntax (`s=SIZE`) does not work with Katherine's avatar. I tried multiple approaches using Github URL syntax but none worked (strangely, they all work for Andy Beet's avatar). I pivoted to writing the HTML myself, which gets the intended result but is maybe more advanced than we'd like. Ideally, if we can figure out why Github's URL syntax won't work, we can switch back to the more readable solution we commonly use. 

### Reviewer instructions:
Please review changed files for proper content and syntax. The README can be previewed [here](https://github.com/NEFSC/READ-EDAB-CVA2.0/blob/docs/i28-cleanup-documentation/README.md).
