### PR TITLE
Docs(#31): Organize reference functions by use

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -10,30 +10,12 @@ reference:
   - apply_sensitivity_logic_rule
   - avg_model_data
   - build_sdm
-  - calculate_attribute_score
-  - calculate_data_quality
-  - calculate_directionality
-  - calculate_directionality_certainty
-  - calculate_distribution_shifts
-  - calculate_model_confidence
-  - calculate_raw_exposure
-  - calculate_sdm_variable_importance
-  - calculate_sensitivity
-  - calculate_sensitivity_certainty
+  - starts_with("calculate_")
   - pseudo_r2_brt
 - title: "Create Outputs"
   desc: "Functions used to create figures, tables and output files"
 - contents:
-  - make_evaluation_csv
-  - make_exposure_plots
-  - make_exposure_table
-  - make_sdm_plots
-  - make_sdm_predictions
-  - make_sdm_reports
-  - make_sensitivity_barplots
-  - make_sensitivity_table
-  - make_total_exposure
-  - make_variable_exposure
+  - starts_with("make_")
 - title: "Data Processing"
   desc: "Functions used to pull and process data"
 - contents:
@@ -44,9 +26,7 @@ reference:
   - normalize_model_data
   - normalize_variable_weights
   - predict_to_raster
-  - pull_mom6_forecast
-  - pull_mom6_hindcast
-  - pull_sdm_preds
+  - starts_with("pull_")
   - rank_exposure
   - raster_to_df
   - remove_corr

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -3,3 +3,65 @@ url: https://nefsc.github.io/READ-EDAB-CVA2.0/
 template:
   bootstrap: 5
 
+reference:
+- title: "Calculations"
+  desc: "Functions used to calculate scores and metrics"
+- contents:
+  - apply_sensitivity_logic_rule
+  - avg_model_data
+  - build_sdm
+  - calculate_attribute_score
+  - calculate_data_quality
+  - calculate_directionality
+  - calculate_directionality_certainty
+  - calculate_distribution_shifts
+  - calculate_model_confidence
+  - calculate_raw_exposure
+  - calculate_sdm_variable_importance
+  - calculate_sensitivity
+  - calculate_sensitivity_certainty
+  - pseudo_r2_brt
+- title: "Create Outputs"
+  desc: "Functions used to create figures, tables and output files"
+- contents:
+  - make_evaluation_csv
+  - make_exposure_plots
+  - make_exposure_table
+  - make_sdm_plots
+  - make_sdm_predictions
+  - make_sdm_reports
+  - make_sensitivity_barplots
+  - make_sensitivity_table
+  - make_total_exposure
+  - make_variable_exposure
+- title: "Data Processing"
+  desc: "Functions used to pull and process data"
+- contents:
+  - build_fisheries_raster
+  - match_guilds
+  - match_pa_model_rasters
+  - merge_fisheries_rasters
+  - normalize_model_data
+  - normalize_variable_weights
+  - predict_to_raster
+  - pull_mom6_forecast
+  - pull_mom6_hindcast
+  - pull_sdm_preds
+  - rank_exposure
+  - raster_to_df
+  - remove_corr
+  - set_binary_pa
+  - standardize_fisheries_data
+- title: "Statistics & Evaluation"
+  desc: "Functions used to calculate statistics and analyze outputs"
+- contents:
+  - bhatt_coeff_brt
+  - bhattacharyya_stat_brt
+  - cross_validate_sdm
+  - eval_brt
+  - eval_kfold_brt
+  - evaluate_ensemble
+  - evaluate_sdm
+  - save_auc_brt
+  - save_tss_brt
+  - sd_model_data


### PR DESCRIPTION
### Justification
The reference section of the `pkgdown` site needs better organization. This change proposes new groupings for package functions by use case to better organize the page.

Fixes #31 

### Types of changes
- [x] Other change (if none of the other choices apply) 

### Further comments
This was actually fairly challenging given I don't know what each function does. The name and documentation of the function was not always clear enough to fully understand which grouping should be assigned to it. Unlike many of our packages, there is not uniform prefixing. So while many functions begin with the same prefix (e.g. `make_` or `calculate_`), most do not and there is generally no naming convention.

### Reviewer instructions:
Please first review the changed file (`_pkgdown.yml`). If these groupings are not what you envisioned, close this PR with a message explaining that it needs more work. Otherwise, please also test and review the pkgdown site using the code `pkgdown::build_site()`.