### PR TITLE
chore(#45): add comments to enable badges in rhs column

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # spatialcva (Climate Vulnerability Assessment 2.0)
-
+<!-- badges: start --> 
 [![gitleaks](https://github.com/NEFSC/READ-EDAB-CVA2.0/actions/workflows/secretScan.yml/badge.svg)](https://github.com/NEFSC/READ-EDAB-CVA2.0/actions/workflows/secretScan.yml)
 [![R-CMD-check](https://github.com/NEFSC/READ-EDAB-CVA2.0/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/NEFSC/READ-EDAB-CVA2.0/actions/workflows/R-CMD-check.yaml)
 [![format-check.yaml](https://github.com/NEFSC/READ-EDAB-CVA2.0/actions/workflows/format-check.yml/badge.svg?branch=main)](https://github.com/NEFSC/READ-EDAB-CVA2.0/actions/workflows/format-check.yml)
 [![pkgdown](https://github.com/NEFSC/READ-EDAB-CVA2.0/actions/workflows/pkgdown.yaml/badge.svg)](https://github.com/NEFSC/READ-EDAB-CVA2.0/actions/workflows/pkgdown.yaml)
+<!-- badges: end -->
 
 ## Overview
 


### PR DESCRIPTION
Your commits explain the `who`, `what`, `where` and `when` of these changes. Your code shows the `how`. You do not need to reiterate this. This PR should complete the big picture by telling the `why`.

### Justification

The badges in the readme get translated differently if comments are added to the readme.md They are best displayed in the rhs column of the pkgdown index page rather than under the package name.

fixes #45 

### Types of changes

What types of changes does your code introduce? Put an `x` in the boxes that apply

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other change (if none of the other choices apply) 

### Reviewer instructions:

`pkgdown::build_site()` - you should se the badges render in a different location

### Formatting

This repo contains an `air.toml` file that automatically formats code to a set of standards.
It is preferred that contributors and reviewers install the [air](https://posit-dev.github.io/air/) formatting tool.
